### PR TITLE
Added test instructions, removed unused dev dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ To compile curve25519 from C souce files in `/native`, install
 grunt compile
 ```
 
+To test, you will need an account with [Sauce Labs](https://saucelabs.com). Get your username and API key, 
+then set the appropriate envirionment variables to run the tests.
+
+```sh
+SAUCE_USERNAME="your-sauce-username" SAUCE_ACCESS_KEY="your-sauce-key" grunt test
+```
+
+
 ## License
 
 Copyright 2015-2016 Open Whisper Systems

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^1.1.0",
     "grunt-preen": "^1.0.0",


### PR DESCRIPTION
Added instructions for setting up tests with Sauce Labs credentials.

Removed unnecessary dev dependency on grunt-sass.