### PR TITLE
InMemoryProtocolStore should not trust unknown identifier

### DIFF
--- a/test/InMemorySignalProtocolStore.js
+++ b/test/InMemorySignalProtocolStore.js
@@ -38,7 +38,7 @@ SignalProtocolStore.prototype = {
     }
 		var trusted = this.get('identityKey' + identifier);
     if (trusted === undefined) {
-      return Promise.resolve(true);
+      return Promise.resolve(false);
     }
     return Promise.resolve(util.toString(identityKey) === util.toString(trusted));
 	},


### PR DESCRIPTION
isTrustedIdentity returns true for any identityKey if the identifier is unknown to it.