### PR TITLE
Expose ability to fully delete existing sessions - for resets

### DIFF
--- a/src/SessionCipher.js
+++ b/src/SessionCipher.js
@@ -398,6 +398,20 @@ SessionCipher.prototype = {
         return this.storage.storeSession(address, record.serialize());
       }.bind(this));
     }.bind(this));
+  },
+  deleteAllSessionsForDevice: function() {
+    // Used in session reset scenarios, where we really need to delete
+    var address = this.remoteAddress.toString();
+    return Internal.SessionLock.queueJobForNumber(address, function() {
+      return this.getRecord(address).then(function(record) {
+        if (record === undefined) {
+            return;
+        }
+
+        record.deleteAllSessions();
+        return this.storage.storeSession(address, record.serialize());
+      }.bind(this));
+    }.bind(this));
   }
 };
 
@@ -417,4 +431,5 @@ libsignal.SessionCipher = function(storage, remoteAddress, options) {
     this.getRemoteRegistrationId = cipher.getRemoteRegistrationId.bind(cipher);
     this.hasOpenSession = cipher.hasOpenSession.bind(cipher);
     this.closeOpenSessionForDevice = cipher.closeOpenSessionForDevice.bind(cipher);
+    this.deleteAllSessionsForDevice = cipher.deleteAllSessionsForDevice.bind(cipher);
 };

--- a/src/SessionRecord.js
+++ b/src/SessionRecord.js
@@ -263,6 +263,10 @@ Internal.SessionRecord = function() {
                 delete sessions[util.toString(oldestBaseKey)];
             }
         },
+        deleteAllSessions: function() {
+            // Used primarily in session reset scenarios, where we really delete sessions
+            this.sessions = {};
+        }
     };
 
     return SessionRecord;


### PR DESCRIPTION
Up until this point, `reset secure session` in the desktop app just archived sessions. The iOS and Android apps fully delete sessions in this case, which is the right behavior. This pull request exposes full deletes for parity with the mobile apps.