### PR TITLE
Remove 1000 messageKey limit entirely, along with custom limits

### DIFF
--- a/dist/libsignal-protocol.js
+++ b/dist/libsignal-protocol.js
@@ -36016,14 +36016,7 @@ libsignal.SessionBuilder = function (storage, remoteAddress) {
   this.processV3 = builder.processV3.bind(builder);
 };
 
-function SessionCipher(storage, remoteAddress, options) {
-  options = options || {};
-
-  if (typeof options.messageKeysLimit === 'undefined') {
-    options.messageKeysLimit = 1000;
-  }
-
-  this.messageKeysLimit = options.messageKeysLimit;
+function SessionCipher(storage, remoteAddress) {
   this.remoteAddress = remoteAddress;
   this.storage = storage;
 }
@@ -36296,11 +36289,6 @@ SessionCipher.prototype = {
     });
   },
   fillMessageKeys: function(chain, counter) {
-      if (this.messageKeysLimit && Object.keys(chain.messageKeys).length >= this.messageKeysLimit) {
-          console.log("Too many message keys for chain");
-          return Promise.resolve(); // Stalker, much?
-      }
-
       if (chain.chainKey.counter >= counter) {
           return Promise.resolve(); // Already calculated
       }
@@ -36433,8 +36421,8 @@ SessionCipher.prototype = {
   }
 };
 
-libsignal.SessionCipher = function(storage, remoteAddress, options) {
-    var cipher = new SessionCipher(storage, remoteAddress, options);
+libsignal.SessionCipher = function(storage, remoteAddress) {
+    var cipher = new SessionCipher(storage, remoteAddress);
 
     // returns a Promise that resolves to a ciphertext object
     this.encrypt = cipher.encrypt.bind(cipher);

--- a/src/SessionCipher.js
+++ b/src/SessionCipher.js
@@ -1,11 +1,4 @@
-function SessionCipher(storage, remoteAddress, options) {
-  options = options || {};
-
-  if (typeof options.messageKeysLimit === 'undefined') {
-    options.messageKeysLimit = 1000;
-  }
-
-  this.messageKeysLimit = options.messageKeysLimit;
+function SessionCipher(storage, remoteAddress) {
   this.remoteAddress = remoteAddress;
   this.storage = storage;
 }
@@ -278,11 +271,6 @@ SessionCipher.prototype = {
     });
   },
   fillMessageKeys: function(chain, counter) {
-      if (this.messageKeysLimit && Object.keys(chain.messageKeys).length >= this.messageKeysLimit) {
-          console.log("Too many message keys for chain");
-          return Promise.resolve(); // Stalker, much?
-      }
-
       if (chain.chainKey.counter >= counter) {
           return Promise.resolve(); // Already calculated
       }
@@ -415,8 +403,8 @@ SessionCipher.prototype = {
   }
 };
 
-libsignal.SessionCipher = function(storage, remoteAddress, options) {
-    var cipher = new SessionCipher(storage, remoteAddress, options);
+libsignal.SessionCipher = function(storage, remoteAddress) {
+    var cipher = new SessionCipher(storage, remoteAddress);
 
     // returns a Promise that resolves to a ciphertext object
     this.encrypt = cipher.encrypt.bind(cipher);


### PR DESCRIPTION
As discussed with Moxie on 2/12. A good simplification, and matches iOS/Android limits. Important for desktop because it's often the case that our users only receive messages on desktop, sending primarily with their mobile device.

Should fix https://github.com/signalapp/Signal-Desktop/issues/2044