### PR TITLE
Throw error if asked to jump forward in chain by over 2000

### DIFF
--- a/dist/libsignal-protocol.js
+++ b/dist/libsignal-protocol.js
@@ -36305,6 +36305,10 @@ SessionCipher.prototype = {
           return Promise.resolve(); // Already calculated
       }
 
+      if (counter - chain.chainKey.counter > 2000) {
+          throw new Error('Over 2000 messages into the future!');
+      }
+
       if (chain.chainKey.key === undefined) {
           throw new Error("Got invalid request to extend chain after it was already closed");
       }

--- a/src/SessionCipher.js
+++ b/src/SessionCipher.js
@@ -287,6 +287,10 @@ SessionCipher.prototype = {
           return Promise.resolve(); // Already calculated
       }
 
+      if (counter - chain.chainKey.counter > 2000) {
+          throw new Error('Over 2000 messages into the future!');
+      }
+
       if (chain.chainKey.key === undefined) {
           throw new Error("Got invalid request to extend chain after it was already closed");
       }


### PR DESCRIPTION
As `libsignal-protocol-java` has had for more than three years. This check was present when it was first pulled out into its own repo in late 2014: 

https://github.com/signalapp/libsignal-protocol-java/blob/60800e155612bea797eed93c67046a23d26054cc/src/main/java/org/whispersystems/libaxolotl/SessionCipher.java#L383-L385