### PR TITLE
Remove logging from verifyMAC on mismatch

### DIFF
--- a/dist/libsignal-protocol.js
+++ b/dist/libsignal-protocol.js
@@ -35291,8 +35291,6 @@ var Internal = Internal || {};
                 result = result | (a[i] ^ b[i]);
             }
             if (result !== 0) {
-                console.log('Our MAC  ', dcodeIO.ByteBuffer.wrap(calculated_mac).toHex());
-                console.log('Their MAC', dcodeIO.ByteBuffer.wrap(mac).toHex());
                 throw new Error("Bad MAC");
             }
         });

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -101,8 +101,6 @@ var Internal = Internal || {};
                 result = result | (a[i] ^ b[i]);
             }
             if (result !== 0) {
-                console.log('Our MAC  ', dcodeIO.ByteBuffer.wrap(calculated_mac).toHex());
-                console.log('Their MAC', dcodeIO.ByteBuffer.wrap(mac).toHex());
                 throw new Error("Bad MAC");
             }
         });


### PR DESCRIPTION
We don't use it when debugging anyway.