### PR TITLE
Concord JSHint Standards with Signal-Desktop, update to ES6 getPrototypeOf

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -29,6 +29,7 @@
     "debug"         : false,
     "eqnull"        : false,
     "es5"           : false,
+    "esversion"     : 6,
     "esnext"        : false,
     "moz"           : false,
     "evil"          : false,
@@ -37,13 +38,13 @@
     "globalstrict"  : false,
     "iterator"      : false,
     "lastsemic"     : false,
-    "laxbreak"      : false,
+    "laxbreak"      : true,
     "laxcomma"      : false,
     "loopfunc"      : false,
     "multistr"      : false,
     "noyield"       : false,
     "notypeof"      : false,
-    "proto"         : true,
+    "proto"         : false,
     "scripturl"     : false,
     "shadow"        : false,
     "sub"           : false,
@@ -67,5 +68,6 @@
     "worker"        : false,
     "wsh"           : false,
     "yui"           : false,
-    "globals"       : {}
+    "globals"       : {},
+    "-W100"         : true
 }

--- a/src/SessionRecord.js
+++ b/src/SessionRecord.js
@@ -19,15 +19,15 @@ Internal.SessionRecord = function() {
     var OLD_RATCHETS_MAX_LENGTH = 10;
     var SESSION_RECORD_VERSION = 'v1';
 
-    var StaticByteBufferProto = new dcodeIO.ByteBuffer().__proto__;
-    var StaticArrayBufferProto = new ArrayBuffer().__proto__;
-    var StaticUint8ArrayProto = new Uint8Array().__proto__;
+    var StaticByteBufferProto = Object.getPrototypeOf(new dcodeIO.ByteBuffer());
+    var StaticArrayBufferProto = Object.getPrototypeOf(new ArrayBuffer());
+    var StaticUint8ArrayProto = Object.getPrototypeOf(new Uint8Array());
 
     function isStringable(thing) {
         return (thing === Object(thing) &&
-                (thing.__proto__ == StaticArrayBufferProto ||
-                    thing.__proto__ == StaticUint8ArrayProto ||
-                    thing.__proto__ == StaticByteBufferProto));
+                (Object.getPrototypeOf(thing) == StaticArrayBufferProto ||
+                    Object.getPrototypeOf(thing) == StaticUint8ArrayProto ||
+                    Object.getPrototypeOf(thing) == StaticByteBufferProto));
     }
     function ensureStringed(thing) {
         if (typeof thing == "string" || typeof thing == "number" || typeof thing == "boolean") {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,7 +5,7 @@
 var util = (function() {
     'use strict';
 
-    var StaticArrayBufferProto = new ArrayBuffer().__proto__;
+    var StaticArrayBufferProto = Object.getPrototypeOf(new ArrayBuffer());
 
     return {
         toString: function(thing) {
@@ -19,7 +19,7 @@ var util = (function() {
                 return undefined;
             }
             if (thing === Object(thing)) {
-                if (thing.__proto__ == StaticArrayBufferProto) {
+                if (Object.getPrototypeOf(thing) == StaticArrayBufferProto) {
                     return thing;
                 }
             }


### PR DESCRIPTION
Attempt to rectify both JSHint profiles between here and [Signal-Desktop](https://github.com/signalapp/Signal-Desktop/blob/development/.jshintrc).

This upgrades the file to match, and then removes the legacy '__proto__' and invokes the new ES6 `.getPrototypeOf()` method.

An extra pair of eyes for testing this would be helpful -- my machine is having trouble closing the SauceLabs tunnel but I believe they're passing regardless. Sanity checks are welcome!