### PR TITLE
Add grunt task to run tests vs headless chrome

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,7 +232,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint', 'jscs', 'connect', 'saucelabs-mocha']);
   grunt.registerTask('default', ['concat']);
   grunt.registerTask('build', ['compile', 'concat']);
-  grunt.registerTask('localTest', function () {
+  grunt.registerTask('testLocal', ['jshint', 'jscs'], function () {
     const {runner} = require('mocha-headless-chrome');
 
     grunt.event.once('connect.https.listening', async (host, port) => {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,13 @@ module.exports = function(grunt) {
           base: '.',
           port: 9998
         }
+      },
+      https: {
+        options: {
+          base: '.',
+          port: 9998,
+          protocol: 'https'
+        }
       }
     },
     'saucelabs-mocha': {
@@ -225,5 +232,30 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint', 'jscs', 'connect', 'saucelabs-mocha']);
   grunt.registerTask('default', ['concat']);
   grunt.registerTask('build', ['compile', 'concat']);
+  grunt.registerTask('localTest', function () {
+    const {runner} = require('mocha-headless-chrome');
 
+    grunt.event.once('connect.https.listening', async (host, port) => {
+      const done = this.async();
+      const url = `https://${host}:${port}/test`;
+      const options = {
+        file: url,
+        timeout: 120000,
+        args: ['no-sandbox']
+      };
+      runner(options)
+        .then(({result: {failures}})=> {
+          if (failures && failures.length) {
+            done(new Error(failures.map(failure => `${failure.fullTitle}: ${failure.err.stack}`).join('\n') + '\n'));
+          } else {
+            done();
+          }
+        })
+        .catch(err => {
+          grunt.log.writeln(err);
+          done(err);
+        });
+    });
+    grunt.task.run('connect:https:keepalive');
+  });
 };

--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ To compile curve25519 from C souce files in `/native`, install
 grunt compile
 ```
 
+## Testing
+
+In order to run the automated tests, you must sign up for a [SauceLabs](https://saucelabs.com/) account, and use your username and access code to run the test. Once these are generated, include them in the test command.
+
+```
+SAUCE_USERNAME="your-usrname" SAUCE_ACCESS_KEY="your-access-key" grunt test
+```
+
 ## License
 
 Copyright 2015-2018 Open Whisper Systems

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ In order to run the automated tests, you must sign up for a [SauceLabs](https://
 SAUCE_USERNAME="your-usrname" SAUCE_ACCESS_KEY="your-access-key" grunt test
 ```
 
+There is also a task to run tests against headless chrome locally: `grunt localTest`.
+
+For information on how to configure options, please see:
+
+[mocha-headless-chrome](https://www.npmjs.com/package/mocha-headless-chrome)
+
 ## License
 
 Copyright 2015-2018 Open Whisper Systems

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ In order to run the automated tests, you must sign up for a [SauceLabs](https://
 SAUCE_USERNAME="your-usrname" SAUCE_ACCESS_KEY="your-access-key" grunt test
 ```
 
-There is also a task to run tests against headless chrome locally: `grunt localTest`.
+There is also a task to run tests against headless chrome locally: 
+
+`grunt testLocal` or `yarn run testLocal`
 
 For information on how to configure options, please see:
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "test": "grunt test",
+    "testLocal": "grunt testLocal",
     "lint": "grunt jshint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "grunt-preen": "^1.0.0",
     "grunt-saucelabs": "^8.3.3",
     "jquery": "^2.2.3",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "mocha-headless-chrome": "^2.0.0"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
I didn't want to make a sauce labs account to run tests against this.

This uses https://www.npmjs.com/package/mocha-headless-chrome to run mocha tests in the background vs headless chrome using puppeteer.

This also includes the commit from https://github.com/signalapp/libsignal-protocol-javascript/pull/50

with notes on running these tests vs sauce labs.

On a side note, I see that the build artifacts from this repository are copy+pasted into signal-desktop. I would very much like to see this protocol library become a first class citizen on npm and be a usable library for both node and web/electron, and if there's support from signal for doing this and reviewing PRs, I can make that happen.