### PR TITLE
always pass the full address to isTrustedIdentity

### DIFF
--- a/src/SessionBuilder.js
+++ b/src/SessionBuilder.js
@@ -7,7 +7,7 @@ SessionBuilder.prototype = {
   processPreKey: function(device) {
     return Internal.SessionLock.queueJobForNumber(this.remoteAddress.toString(), function() {
       return this.storage.isTrustedIdentity(
-          this.remoteAddress.getName(), device.identityKey, this.storage.Direction.SENDING
+          this.remoteAddress.toString(), device.identityKey, this.storage.Direction.SENDING
       ).then(function(trusted) {
         if (!trusted) {
           throw new Error('Identity key changed');
@@ -60,7 +60,7 @@ SessionBuilder.prototype = {
   processV3: function(record, message) {
     var preKeyPair, signedPreKeyPair, session;
     return this.storage.isTrustedIdentity(
-        this.remoteAddress.getName(), message.identityKey.toArrayBuffer(), this.storage.Direction.RECEIVING
+        this.remoteAddress.toString(), message.identityKey.toArrayBuffer(), this.storage.Direction.RECEIVING
     ).then(function(trusted) {
         if (!trusted) {
             var e = new Error('Unknown identity key');

--- a/src/SessionCipher.js
+++ b/src/SessionCipher.js
@@ -77,7 +77,7 @@ SessionCipher.prototype = {
                   result.set(new Uint8Array(mac, 0, 8), encodedMsg.byteLength + 1);
 
                   return this.storage.isTrustedIdentity(
-                      this.remoteAddress.getName(), util.toArrayBuffer(session.indexInfo.remoteIdentityKey), this.storage.Direction.SENDING
+                      this.remoteAddress.toString(), util.toArrayBuffer(session.indexInfo.remoteIdentityKey), this.storage.Direction.SENDING
                   ).then(function(trusted) {
                       if (!trusted) {
                           throw new Error('Identity key changed');
@@ -159,7 +159,7 @@ SessionCipher.prototype = {
                     }
 
                     return this.storage.isTrustedIdentity(
-                        this.remoteAddress.getName(), util.toArrayBuffer(result.session.indexInfo.remoteIdentityKey), this.storage.Direction.RECEIVING
+                        this.remoteAddress.toString(), util.toArrayBuffer(result.session.indexInfo.remoteIdentityKey), this.storage.Direction.RECEIVING
                     ).then(function(trusted) {
                         if (!trusted) {
                             throw new Error('Identity key changed');


### PR DESCRIPTION
For consistency with `loadIdentityKey` and `saveIdentity`. See also 1fe18c3384ccc2c149a4679d16e523d661543f6b.

This is quite important in the OMEMO use case.